### PR TITLE
updated StillImageFiltersViewController.swift

### DIFF
--- a/iOS9Sampler/SampleViewControllers/StillImageFiltersViewController.swift
+++ b/iOS9Sampler/SampleViewControllers/StillImageFiltersViewController.swift
@@ -22,6 +22,7 @@ class StillImageFiltersViewController: UIViewController, UIPickerViewDataSource,
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        imageView.backgroundColor = UIColor.blackColor();
         orgImage = imageView.image
 
         let exceptCategories = [


### PR DESCRIPTION
http://d.hatena.ne.jp/shu223/20150917/1442440780 に
「今のところ29のフィルタを試せますが、`CIEdgeWork` と `CISpotLight` については正常に機能していません。」とありましたが"CIEdgeWork"についてですが、透明と白色の二色になるので、見えていないだけのような気がしております。
imageView.backgroundColor = UIColor.blackColor();
とかしてみてはいかがでしょうか？　
